### PR TITLE
ESS: Send relative paths in filewriting pl72 run_start messages

### DIFF
--- a/nicos_ess/bifrost/setups/system.py
+++ b/nicos_ess/bifrost/setups/system.py
@@ -28,7 +28,6 @@ devices = dict(
     Exp=device('nicos_ess.devices.experiment.EssExperiment',
                description='experiment object',
                dataroot='/opt/nicos-data',
-               filewriter_root='/opt/nicos-data/bifrost',
                sample='Sample',
                cache_filepath='/opt/nicos-data/bifrost/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/cspec/setups/system.py
+++ b/nicos_ess/cspec/setups/system.py
@@ -35,7 +35,6 @@ devices = dict(
     Exp=device('nicos_ess.devices.experiment.EssExperiment',
                description='experiment object',
                dataroot='/opt/nicos-data',
-               filewriter_root='/opt/nicos-data/cspec',
                sample='Sample',
                cache_filepath='/opt/nicos-data/cspec/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/devices/experiment.py
+++ b/nicos_ess/devices/experiment.py
@@ -29,8 +29,8 @@ from yuos_query.exceptions import BaseYuosException
 from yuos_query.yuos_client import YuosCacheClient
 
 from nicos import session
-from nicos.core import SIMULATION, Override, Param, UsageError, \
-    absolute_path, listof, mailaddress
+from nicos.core import SIMULATION, Override, Param, UsageError, listof, \
+    mailaddress
 from nicos.devices.experiment import Experiment
 from nicos.utils import createThread
 
@@ -43,10 +43,6 @@ class EssExperiment(Experiment):
                   category='experiment',
                   mandatory=True,
                   userparam=False),
-        'filewriter_root':
-            Param('Root data path on the file writer server under which all '
-                  'proposal specific paths exist.', mandatory=True,
-                  type=absolute_path),
         'update_interval':
             Param('Time interval (in hrs.) for cache updates',
                   default=1.0,
@@ -131,7 +127,10 @@ class EssExperiment(Experiment):
         Experiment.update(self, title, users, localcontacts)
 
     def proposalpath_of(self, proposal):
-        return path.join(self.filewriter_root, time.strftime('%Y'), proposal)
+        instrument_name = ''
+        if session.instrument:
+            instrument_name = session.instrument.name.lower()
+        return path.join(instrument_name, time.strftime('%Y'), proposal)
 
     def _check_users(self, users):
         if not users:

--- a/nicos_ess/dream/setups/system.py
+++ b/nicos_ess/dream/setups/system.py
@@ -25,7 +25,6 @@ devices = dict(
     Exp=device('nicos_ess.devices.experiment.EssExperiment',
                description='experiment object',
                dataroot='/opt/nicos-data',
-               filewriter_root='/opt/nicos-data/dream',
                sample='Sample',
                cache_filepath='/opt/nicos-data/dream/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/estia/setups/special/config.py
+++ b/nicos_ess/estia/setups/special/config.py
@@ -2,5 +2,4 @@ description = 'Generic configuration settings for ESTIA'
 group = 'configdata'
 
 ESTIA_DATA_ROOT = '/opt/nicos-data'
-ESTIA_FILEWRITER_ROOT = '/opt/nicos-data/estia'
 KAFKA_BROKERS = ["localhost:9092"]

--- a/nicos_ess/estia/setups/system.py
+++ b/nicos_ess/estia/setups/system.py
@@ -27,7 +27,6 @@ devices = dict(
     Exp=device('nicos_ess.devices.experiment.EssExperiment',
                description='experiment object',
                dataroot='/opt/nicos-data',
-               filewriter_root='/ess/data/ymir',
                sample='Sample',
                cache_filepath='/opt/nicos-data/estia/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/loki/setups/system.py
+++ b/nicos_ess/loki/setups/system.py
@@ -28,7 +28,6 @@ devices = dict(
         'nicos_ess.devices.experiment.EssExperiment',
         description='experiment object',
         dataroot='/opt/nicos-data',
-        filewriter_root='/ess/data/loki',
         sample='Sample',
         cache_filepath='/opt/nicos-data/loki/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/miracles/setups/system.py
+++ b/nicos_ess/miracles/setups/system.py
@@ -26,7 +26,6 @@ devices = dict(
         'nicos_ess.devices.experiment.EssExperiment',
         description='experiment object',
         dataroot='/opt/nicos-data',
-        filewriter_root='/opt/nicos-data/miracles',
         sample='Sample',
         cache_filepath='/opt/nicos-data/miracles/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/odin/setups/system.py
+++ b/nicos_ess/odin/setups/system.py
@@ -28,7 +28,6 @@ devices = dict(
         'nicos_ess.devices.experiment.EssExperiment',
         description='experiment object',
         dataroot='/opt/nicos-data',
-        filewriter_root='/opt/nicos-data/odin',
         sample='Sample',
         cache_filepath='/opt/nicos-data/odin/cached_proposals.json'),
     conssink=device(

--- a/nicos_ess/ymir/setups/system.py
+++ b/nicos_ess/ymir/setups/system.py
@@ -35,7 +35,6 @@ devices = dict(
         'nicos_ess.devices.experiment.EssExperiment',
         description='experiment object',
         dataroot='/opt/nicos-data',
-        filewriter_root='/ess/data/ymir',
         sample='Sample',
         cache_filepath='/opt/nicos-data/ymir/cached_proposals.json'),
     conssink=device(


### PR DESCRIPTION
We currently send absolute file paths from NICOS to the Filewriter. The Filewriter will soon start prepending a base directory to all received paths, so NICOS should stop sending the base directory as part of the pl72 message.

Change-Id: I470579c670816a415d405c71f87a5f143b81a4e2